### PR TITLE
Add automatic changelog generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,10 +32,6 @@ brew:
   description: "Draft GitHub Release of the next semver in web browser"
   homepage: "https://github.com/mroth/bump"
   skip_upload: false
+# disable changelog generation entirely, since bump will manage that itself!
 changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^docs:'
-    - '^chore:'
-    - '^trivial:'
+  skip: true

--- a/git.go
+++ b/git.go
@@ -19,11 +19,23 @@ import (
 // It will automatically use an OAuth scoped token if GITHUB_RELEASE environment
 // variable is set, or an unauthed client otherwise.
 func getLatestRelease(owner, repo string) (*github.RepositoryRelease, error) {
-	client := defaultGithubClient()
-	ctx := context.Background()
+	client, ctx := defaultGithubClient(), context.Background()
 	defer timeTrack(time.Now(), "client.Repositories.GetLatestRelease()")
 	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)
 	return release, err
+}
+
+// compareRelease is a convenience function wrapping retrieval of a commits
+// comparison between current default branch HEAD and a given release tagName,
+// via the GitHub API.
+//
+// It will automatically use an OAuth scoped token if GITHUB_RELEASE environment
+// variable is set, or an unauthed client otherwise.
+func compareRelease(owner, repo, tagName string) (*github.CommitsComparison, error) {
+	client, ctx := defaultGithubClient(), context.Background()
+	defer timeTrack(time.Now(), "client.Repositories.CompareCommits()")
+	cc, _, err := client.Repositories.CompareCommits(ctx, owner, repo, tagName, "HEAD")
+	return cc, err
 }
 
 // defaultGithubClient returns a OAuth scoped Github API Client if GITHUB_TOKEN

--- a/main.go
+++ b/main.go
@@ -1,16 +1,20 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/google/go-github/v25/github"
 	"github.com/pkg/browser"
 )
 
-// build set by goreleaser on production builds
+// build info set by goreleaser during production builds
 var (
 	buildVersion = "dev"
 	buildCommit  = "none"
@@ -55,45 +59,125 @@ func main() {
 			logVerbose("%v", err)
 			usage()
 		}
-		logVerbose("wd detected as git repo with github remote %v/%v", owner, repo)
+		logVerbose("detected .git repo with github remote %v/%v", owner, repo)
 	}
 
 	// get latest release version from github
 	logVerbose("checking github for latest release of %v/%v", owner, repo)
-	release, err := getLatestRelease(owner, repo)
+	previousRelease, err := getLatestRelease(owner, repo)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// try to parse tag name from current release into a semantic version
-	tag := release.GetTagName()
-	version, err := semver.NewVersion(tag)
+	previousVersion, err := semver.NewVersion(previousRelease.GetTagName())
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("🌻 Latest release of %v (published %v)\n",
+		boldStyler(fmt.Sprintf("%v/%v: %v", owner, repo, previousVersion)),
+		previousRelease.GetPublishedAt().Format("2006 Jan 2"),
+	)
+
+	// retrieve changes since last release via GitHub API
+	comparison, err := compareRelease(owner, repo, previousRelease.GetTagName())
+	if err != nil {
+		log.Fatal("failed to retrieve commits", err)
+	}
+
+	// display abbreviated changelog to user in CLI, to hopefully aide them in
+	// making a decision about what the next semver should be.
+	changelog := screenChangelog(comparison)
+	fmt.Println(changelog)
+
+	// invoke interactive prompt UI allowing user to select next version
+	nextVersion, err := prompt(previousVersion)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// invoke interactive prompt UI helping user select next version
-	nextVersion, err := prompt(owner, repo, version, release)
-	if err != nil {
-		log.Fatal(err)
-	}
+	// create draft URL embedding markdown changelog for next version...
+	body := strings.Join([]string{
+		markdownChangelog(comparison),
+		comparisonURL(owner, repo, previousVersion, nextVersion),
+	}, "\n")
+	draftURL := draftReleaseURL(owner, repo, nextVersion, body)
 
-	// create draft URL for next version, send user to visit it
-	nextURL := releaseURL(owner, repo, nextVersion)
+	// ...then send user to visit in their web browser!
 	if opts.NoOpen {
-		fmt.Println("To draft release:", nextURL)
+		fmt.Println("To draft release, visit:", draftURL)
 	} else {
-		fmt.Println("✨ Opening", nextURL)
-		err = browser.OpenURL(nextURL)
+		fmt.Println("✨ Drafting new release on GitHub!")
+		logVerbose("Opening browser to: %s", draftURL)
+		err = browser.OpenURL(draftURL)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 }
 
-func releaseURL(owner, repo string, version *semver.Version) string {
+// draftReleaseURL constructs a URL to open a new draft release on GitHub for
+// given owner/repo with a semver compatible tag based on the semver.Version in
+// the tag and title fields, and an encoded body payload to prepopulate the
+// form.
+func draftReleaseURL(owner, repo string, version *semver.Version, body string) string {
 	return fmt.Sprintf(
-		"https://github.com/%s/%s/releases/new?tag=v%s&title=v%s",
-		owner, repo, version.String(), version.String(),
+		"https://github.com/%s/%s/releases/new?tag=v%s&title=v%s&body=%s",
+		owner, repo, version.String(), version.String(), url.QueryEscape(body),
+	)
+}
+
+// markdownChangelog formats a CommitsComparison suitable for displaying on the
+// screen to the user, abbreviated to try to not overflow a 80x24 terminal.
+//
+// Because of this, we only display the 10 most recent commits, with a
+// comparison URL targetting HEAD (as draft is not released), so user can view
+// the full list on GitHub if desired.
+func screenChangelog(comparison *github.CommitsComparison) string {
+	var buf bytes.Buffer
+	buf.WriteString("Changes since previous release:\n\n")
+	const max = 10
+	for i, c := range comparison.Commits {
+		if i >= max {
+			break
+		}
+		buf.WriteString(
+			fmt.Sprintf("  - %v\n",
+				strings.Split(c.Commit.GetMessage(), "\n")[0],
+			),
+		)
+	}
+	numExtraCommits := len(comparison.Commits) - max
+	if numExtraCommits > 0 {
+		buf.WriteString(
+			fmt.Sprintf("\n...%d more commits, %s\n",
+				numExtraCommits, comparison.GetHTMLURL()),
+		)
+	}
+	return buf.String()
+}
+
+// markdownChangelog formats a CommitsComparison suitable for markdown display
+// in a GitHub Flavored Markdown release notes field.
+//
+// TODO: cap max number of commits to display? API returns <=250
+func markdownChangelog(comparison *github.CommitsComparison) string {
+	var buf bytes.Buffer
+	buf.WriteString("## Changelog\n\n")
+	for _, c := range comparison.Commits {
+		buf.WriteString(
+			fmt.Sprintf("- %v %.7s\n",
+				strings.Split(c.Commit.GetMessage(), "\n")[0],
+				c.GetSHA(),
+			),
+		)
+	}
+	return buf.String()
+}
+
+// comparisonURL makes a GitHub web view URL for comparing two tagged semvers.
+func comparisonURL(owner, repo string, base, next *semver.Version) string {
+	return fmt.Sprintf(
+		"https://github.com/%s/%s/compare/v%s...v%s", owner, repo, base, next,
 	)
 }

--- a/prompter.go
+++ b/prompter.go
@@ -6,8 +6,12 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/chzyer/readline"
-	"github.com/google/go-github/v25/github"
 	"github.com/manifoldco/promptui"
+)
+
+var (
+	boldStyler  = promptui.Styler(promptui.FGBold)
+	faintStyler = promptui.Styler(promptui.FGFaint)
 )
 
 type cliVersionOption struct {
@@ -16,25 +20,12 @@ type cliVersionOption struct {
 }
 
 func (o cliVersionOption) String() string {
-	return fmt.Sprintf(
-		"%v%v",
-		o.Name,
-		promptui.Styler(promptui.FGFaint)(
-			fmt.Sprintf(" (%v)", o.Version.String()),
-		),
+	return fmt.Sprintf("%v%v",
+		o.Name, faintStyler(fmt.Sprintf(" (%v)", o.Version.String())),
 	)
 }
 
-func prompt(
-	owner, repo string, currVersion *semver.Version,
-	release *github.RepositoryRelease) (*semver.Version, error) {
-
-	fmt.Printf("🌻 Current version of %v (released %v)\n",
-		promptui.Styler(promptui.FGBold)(fmt.Sprintf("%v/%v: %v",
-			owner, repo, currVersion)),
-		release.GetPublishedAt().Format("2006 Jan 2"),
-	)
-
+func prompt(currVersion *semver.Version) (*semver.Version, error) {
 	// promptui.IconInitial = "🚀" // default is colored ASCII question mark
 	choices := []cliVersionOption{
 		{"patch", currVersion.IncPatch()},
@@ -43,7 +34,7 @@ func prompt(
 	}
 
 	prompt := promptui.Select{
-		Label: "Select semver increment to specify new version",
+		Label: "Select semver increment to specify next version",
 		Items: choices,
 	}
 


### PR DESCRIPTION
With this, `bump` will now query the GitHub API to get a list of commits since the previous release, and show a summary to the user in the CLI to aide in selecting the appropriate semver. Once forwarding to browser to draft actual release, a Markdown formatted version of the changelog is automated populated into the body field.