### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/git.go
+++ b/git.go
@@ -77,7 +77,7 @@ func _detectRemoteURL_LocalGit(path string) (string, error) {
 // 	 https://github.com/mroth/bump.git
 //   git@github.com:mroth/bump.git
 func parseGithubRemote(remoteURL string) (owner, repo string, ok bool) {
-	re := regexp.MustCompile(`^(?:https://|git@)github.com[:/](.*)/(.*?)(?:\.git$|$)`)
+	re := regexp.MustCompile(`^(?:https://|git@)github\.com[:/](.*)/(.*?)(?:\.git$|$)`)
 	matches := re.FindStringSubmatch(remoteURL)
 	if len(matches) < 3 {
 		return

--- a/git_test.go
+++ b/git_test.go
@@ -31,6 +31,17 @@ func Test_parseGithubRemote(t *testing.T) {
 			wantRepo:  "bump",
 			wantOk:    true,
 		},
+		// negative cases: near-miss hostnames should not match
+		{
+			name:      "nearMiss_HTTPS_dotReplaced",
+			remoteURL: "https://githubXcom/mroth/bump.git",
+			wantOk:    false,
+		},
+		{
+			name:      "nearMiss_SSH_dotReplaced",
+			remoteURL: "git@githubXcom:mroth/bump.git",
+			wantOk:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Potential fix for [https://github.com/mroth/bump/security/code-scanning/1](https://github.com/mroth/bump/security/code-scanning/1)

The best fix is to make the hostname literal in the regex by escaping the dot in `github.com`.

In `git.go`, in `parseGithubRemote` (line 80 in the provided snippet), replace:
- `github.com` with `github\.com`

This keeps existing behavior (matching HTTPS and SSH GitHub remotes and extracting owner/repo) while removing unintended host matches. No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
